### PR TITLE
Always fall back on opening in the browser

### DIFF
--- a/src/hike/data/config.py
+++ b/src/hike/data/config.py
@@ -31,6 +31,11 @@ class Configuration:
     markdown_extensions: list[str] = field(default_factory=lambda: [".md", ".markdown"])
     """The file extensions to consider to be Markdown files."""
 
+    markdown_content_types: list[str] = field(
+        default_factory=lambda: ["text/plain", "text/markdown", "text/x-markdown"]
+    )
+    """The content types to consider when looking for remote Markdown content."""
+
     command_line_on_top: bool = False
     """Should the command line live at the top of the screen?"""
 

--- a/src/hike/widgets/viewer.py
+++ b/src/hike/widgets/viewer.py
@@ -34,6 +34,7 @@ from .. import USER_AGENT
 from ..commands import JumpToCommandLine
 from ..data import load_configuration, looks_urllike
 from ..messages import OpenLocation
+from ..support import view_in_browser
 from ..types import HikeHistory, HikeLocation
 
 
@@ -209,8 +210,12 @@ class Viewer(Vertical, can_focus=False):
             ):
                 self.post_message(self.Loaded(self, response.text, remember))
                 return
-        # TODO: Be kind and open the URL outwith the viewer.
-        self.notify("That didn't look like markdown to me.")
+
+        # It doesn't look like Markdown, so let's open it in the browser.
+        self.notify(
+            "That location doesn't look like a Markdown file, opening in your browser..."
+        )
+        view_in_browser(location)
 
     @singledispatchmethod
     def _load_markdown(self, location: Path, remember: bool) -> None:

--- a/src/hike/widgets/viewer.py
+++ b/src/hike/widgets/viewer.py
@@ -32,7 +32,7 @@ from textual.widgets import Label, Markdown, Rule
 # Local imports.
 from .. import USER_AGENT
 from ..commands import JumpToCommandLine
-from ..data import looks_urllike
+from ..data import load_configuration, looks_urllike
 from ..messages import OpenLocation
 from ..types import HikeHistory, HikeLocation
 
@@ -204,8 +204,8 @@ class Viewer(Vertical, can_focus=False):
         # least a form of plain text we can render.
         if content_type := response.headers.get("content-type"):
             if any(
-                content_type.startswith(f"text/{sub_type}")
-                for sub_type in ("plain", "markdown", "x-markdown")
+                content_type.startswith(allowed_type)
+                for allowed_type in load_configuration().markdown_content_types
             ):
                 self.post_message(self.Loaded(self, response.text, remember))
                 return


### PR DESCRIPTION
Tidy up a TODO that was left in, where we've got something that from the name looks like Markdown, but on further inspection very probably isn't; rather than just say we can't open it, pass it off to the OS' browser.

Also makes the content types for testing of a remote file is Markdown configurable.