### PR TITLE
Pin Textual to <2.0.0 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Dave Pearson", email = "davep@davep.org" }
 ]
 dependencies = [
-    "textual>=1.0.0",
+    "textual>=1.0.0,<2",
     "textual-enhanced>=0.6.0",
     "textual-fspicker>=0.2.0",
     "xdg-base-dirs>=6.0.2",


### PR DESCRIPTION
Unsurprisingly the "rewritten" `OptionList` broke previously-valid code, so until I can dive into what's wrong, let's pin to Textual 1.x.