### PR TITLE
Show command palette help in the editor's footer

### DIFF
--- a/src/hike/editor/screen.py
+++ b/src/hike/editor/screen.py
@@ -72,7 +72,7 @@ class Editor(EnhancedScreen[None]):
         """Compose the screen."""
         yield Header()
         yield TextArea.code_editor(language="markdown")
-        yield Footer(show_command_palette=False)
+        yield Footer()
 
     def on_mount(self) -> None:
         """Configure the screen when the DOM is mounted."""


### PR DESCRIPTION
I'd started out with it not there because initially the command palette wasn't going to be in the editor; but then I decided it would be, but then I forgot to remove this.