### PR TITLE
Add `obsidian` as a command for the command line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-**Released: 2025-02-25**
+**Released: WiP**
 
 - Added `obsidian` as a command that the command line understands.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Hike ChangeLog
 
+## Unreleased
+
+**Released: 2025-02-25**
+
+- Added `obsidian` as a command that the command line understands.
+
 ## v0.5.0
 
 **Released: 2025-02-25**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 **Released: WiP**
 
 - Added `obsidian` as a command that the command line understands.
+  ([#41](https://github.com/davep/hike/pull/41))
 
 ## v0.5.0
 

--- a/src/hike/__main__.py
+++ b/src/hike/__main__.py
@@ -46,7 +46,7 @@ def get_args() -> Namespace:
     # The remainder is going to be the initial command.
     parser.add_argument(
         "command",
-        help=("The initial command; " "can be any valid input to Hike's command line."),
+        help="The initial command; can be any valid input to Hike's command line.",
         nargs="*",
     )
 

--- a/src/hike/data/config.py
+++ b/src/hike/data/config.py
@@ -42,6 +42,9 @@ class Configuration:
     main_branches: list[str] = field(default_factory=lambda: ["main", "master"])
     """The branches considered to be main branches on forges."""
 
+    obsidian_vaults: str = "~/Library/Mobile Documents/iCloud~md~obsidian/Documents"
+    """The path to the root of all Obsidian vaults."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/hike/widgets/command_line/obsidian.py
+++ b/src/hike/widgets/command_line/obsidian.py
@@ -1,0 +1,44 @@
+"""Provides a command for browsing Obsidian vaults."""
+
+##############################################################################
+# Python imports.
+from pathlib import Path
+
+##############################################################################
+# Textual imports.
+from textual.widget import Widget
+
+##############################################################################
+# Local imports.
+from ...data import load_configuration
+from ...messages import SetLocalViewRoot
+from .base_command import InputCommand
+
+
+##############################################################################
+class ObsidianCommand(InputCommand):
+    """Change the root directory to your Obsidian vaults"""
+
+    COMMAND = "`obsidian`"
+    ALIASES = "`obs`"
+
+    @classmethod
+    def handle(cls, text: str, for_widget: Widget) -> bool:
+        """Handle the command.
+
+        Args:
+            text: The text of the command.
+            for_widget: The widget to handle the command for.
+
+        Returns:
+            `True` if the command was handled; `False` if not.
+        """
+        if cls.is_command(text):
+            if vaults := Path(load_configuration().obsidian_vaults).expanduser():
+                if vaults.exists() and vaults.is_dir():
+                    for_widget.post_message(SetLocalViewRoot(vaults.resolve()))
+                    return True
+        return False
+
+
+### obsidian.py ends here

--- a/src/hike/widgets/command_line/open_from_forge.py
+++ b/src/hike/widgets/command_line/open_from_forge.py
@@ -51,7 +51,7 @@ class OpenFromForgeCommand(InputCommand):
     | `<owner> <repo>:<branch> <file>` | Open a specific file from a specific branch of a repository |
 
     If `<branch>` is omitted the requested file is looked in the following branches:
-    {', '.join(f'`{branch}`' for branch in load_configuration().main_branches)}.
+    {", ".join(f"`{branch}`" for branch in load_configuration().main_branches)}.
     """
 
     @classmethod

--- a/src/hike/widgets/command_line/widget.py
+++ b/src/hike/widgets/command_line/widget.py
@@ -41,6 +41,7 @@ from .general import (
     QuitCommand,
     ReadMeCommand,
 )
+from .obsidian import ObsidianCommand
 from .open_directory import OpenDirectoryCommand
 from .open_file import OpenFileCommand
 from .open_from_forge import (
@@ -74,6 +75,7 @@ COMMANDS: Final[tuple[type[InputCommand], ...]] = (
     ContentsCommand,
     ReadMeCommand,
     QuitCommand,
+    ObsidianCommand,
 )
 """The commands used for the input."""
 

--- a/src/hike/widgets/command_line/widget.py
+++ b/src/hike/widgets/command_line/widget.py
@@ -134,7 +134,7 @@ class CommandLine(Vertical):
 
     | Command | Aliases | Arguments | Description |
     | --      | --      | --        | --          |
-    {'\n    '.join(sorted(command.help_text() for command in COMMANDS))}
+    {"\n    ".join(sorted(command.help_text() for command in COMMANDS))}
 
     ### ¹Forge support
 


### PR DESCRIPTION
More or less an alias for a `cd` to the root of locally-held Obsidian vaults, if the exist.

Right now it's aimed at how and where I have things on macOS; but the location is configurable so anyone else with a different setup should be able to make it work, I think.