### PR TITLE
Improve how escape works in the command line input

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Hike ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Pressing <kbd>Escape</kbd> in the command line input while there is
+  existing input now clears the input and resets the location in the command
+  history; pressing <kbd>Escape</kbd> while there is no input still exits
+  the application. ([#47](https://github.com/davep/hike/pull/47))
+
 ## v0.6.0
 
 **Released: 2025-03-03**

--- a/src/hike/support/history.py
+++ b/src/hike/support/history.py
@@ -96,6 +96,11 @@ class History(Generic[HistoryItem]):
         self._current = clamp(location, 0, len(self._history) - 1)
         return self
 
+    def goto_end(self) -> Self:
+        """Go to the end of the history."""
+        self.goto(len(self) - 1)
+        return self
+
     def add(self, item: HistoryItem) -> Self:
         """Add an item to the history.
 
@@ -106,8 +111,7 @@ class History(Generic[HistoryItem]):
             Self.
         """
         self._history.append(item)
-        self._current = len(self._history) - 1
-        return self
+        return self.goto_end()
 
     def __len__(self) -> int:
         """The length of the history."""

--- a/src/hike/widgets/command_line/widget.py
+++ b/src/hike/widgets/command_line/widget.py
@@ -243,7 +243,11 @@ class CommandLine(Vertical):
 
     def action_request_exit(self) -> None:
         """Request that the application quits."""
-        self.post_message(Quit())
+        if self.query_one(Input).value:
+            self.query_one(Input).value = ""
+            self.history.goto_end()
+        else:
+            self.post_message(Quit())
 
     def action_history_previous(self) -> None:
         """Move backwards through the command line history."""

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -175,6 +175,20 @@ def test_goto(desired: int, achieved: int) -> None:
 
 
 ##############################################################################
+def test_goto_end() -> None:
+    """We should be able to go to the end of the history."""
+    history = History[None]((None,) * 100)
+    assert history.goto(0).current_location == 0
+    assert history.goto_end().current_location == 99
+
+
+##############################################################################
+def test_goto_end_of_nothing() -> None:
+    """Going to the end when there is no history should cause no problem."""
+    assert History[None]().goto_end().current_location is None
+
+
+##############################################################################
 def test_goto_empty() -> None:
     """Going to a location in an empty list should keep the location as `None`."""
     assert History[None]().goto(42).current_location is None


### PR DESCRIPTION
Empty the input and go to the end of history if escape is pressed, otherwise *then* quit out.