### PR TITLE
Add `x install` as an installation method for hike

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ $ brew install hike
 
 Once installed run the `hike` command.
 
+### X-CMD
+
+The application can be installed using [`x-cmd`](https://x-cmd.com):
+
+```sh
+$ x install hike
+```
+
+Once installed run the `hike` command.
+
 ## Using Hike
 
 The best way to get to know Hike is to read the help screen. Once in the


### PR DESCRIPTION
Hi there,

I’ve added an additional installation method for hike in the README by including the `x install` command, which is part of the `x-cmd` ecosystem. This method provides a unified, cross-platform solution for installing hike easily through the command line interface.

The `x install` command simplifies the process by gathering installation commands across multiple platforms and package managers, making it more convenient for users who are already using `x-cmd`. The installation method is fully compatible with the current system environments like Ubuntu, macOS, and others, as supported by the `x-cmd` community.

Additionally, I’ve written an article introducing hike and its installation via `x install`, which you can find here: [x-cmd.com/install/hike](https://x-cmd.com/install/hike). This article aims to help users better understand hike and how to set it up quickly.

I hope this addition can help new users get started with hike more smoothly. Please let me know if you have any questions or require further adjustments.

Thanks for your time and consideration!