### PR TITLE
Expand the installation section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ $ brew install hike
 
 Once installed run the `hike` command.
 
+### X-CMD
+
+The application can be installed using [`x-cmd`](https://x-cmd.com):
+
+```sh
+$ x install hike
+```
+
+Once installed run the `hike` command.
+
 ## Using Hike
 
 The best way to get to know Hike is to read the help screen. Once in the

--- a/README.md
+++ b/README.md
@@ -24,33 +24,35 @@ that make it easy to view Markdown files on popular git forges.
 The application can be installed using [`pipx`](https://pypa.github.io/pipx/):
 
 ```sh
-$ pipx install hike
+pipx install hike
 ```
-
-Once installed run the `hike` command.
 
 ### Homebrew
 
 The package is available via Homebrew. Use the following commands to install:
 
 ```sh
-$ brew tap davep/homebrew
-$ brew install hike
+brew tap davep/homebrew
+brew install hike
 ```
 
-Once installed run the `hike` command.
+### Other installation methods
 
-### X-CMD
+The following installation methods have been provided by third parties;
+please note that I can't vouch for them myself so use them at your own risk.
+
+#### X-CMD
 
 The application can be installed using [`x-cmd`](https://x-cmd.com):
 
 ```sh
-$ x install hike
+x install hike
 ```
 
-Once installed run the `hike` command.
-
 ## Using Hike
+
+Once you've installed Hike using one of the above methods, you can run the
+application using the `hike` command.
 
 The best way to get to know Hike is to read the help screen. Once in the
 application you can see this by pressing <kbd>F1</kbd>.


### PR DESCRIPTION
This PR cleans up and expands the installation section of the README, removing the `$` before any `sh` command (making it easier for someone to copy/paste commands) and also adds a *"third party"* section for installation methods.

While I'm more than happy to welcome other installation methods, I obviously can't vouch for them so I think it makes sense to mention them as options but make it 100% clear I don't maintain or control them.