### PR TITLE
Add ctrl+r as a backup binding for jumping to the document

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,9 @@
 
 - Unpinned Textual. ([#50](https://github.com/davep/hike/pull/50))
 - Added `local_start_location` to the configuration file.
-  ([#59](https://github.com/davep/hike/pull/59))
+  ([#59](https://github.com/davep/hike/pull/59))  
+- Added <kbd>ctrl</kbd>+<kbd>r</kbd> as an alternative binding for jumping
+  to the document.
 
 ## v0.7.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@
 - Added `local_start_location` to the configuration file.
   ([#59](https://github.com/davep/hike/pull/59))  
 - Added <kbd>ctrl</kbd>+<kbd>r</kbd> as an alternative binding for jumping
-  to the document.
+  to the document. ([#60](https://github.com/davep/hike/pull/60))
 
 ## v0.7.0
 

--- a/src/hike/commands/main.py
+++ b/src/hike/commands/main.py
@@ -32,7 +32,7 @@ class JumpToCommandLine(Command):
 class JumpToDocument(Command):
     """Jump to the markdown document"""
 
-    BINDING_KEY = "ctrl+slash"
+    BINDING_KEY = "ctrl+slash, ctrl+r"
 
 
 ##############################################################################


### PR DESCRIPTION
Closes #57.

See also #55.