### PR TITLE
Add some vim/less-a-like binds to the document viewer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@
   to the document. ([#60](https://github.com/davep/hike/pull/60))
 - Added support for scrolling the markdown up/down half a page.
   ([#62](https://github.com/davep/hike/pull/62))
+- Added some movement key bindings to the markdown document that might be
+  familiar to users of things like `vim` and `less`.
 
 ## v0.7.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
   ([#62](https://github.com/davep/hike/pull/62))
 - Added some movement key bindings to the markdown document that might be
   familiar to users of things like `vim` and `less`.
+  ([#63](https://github.com/davep/hike/pull/63))
 
 ## v0.7.0
 

--- a/src/hike/widgets/viewer.py
+++ b/src/hike/widgets/viewer.py
@@ -98,6 +98,41 @@ class ViewerTitle(Label):
 
 
 ##############################################################################
+class MarkdownScroll(VerticalScroll):
+    """A vertical scrolling widget with more bindings."""
+
+    HELP = """
+    ## Movement
+
+    As well as using the common set of cursor and page keys, the following
+    keys are available for movement within the markdown document:
+    """
+
+    BINDINGS = [
+        HelpfulBinding("j, e, enter", "scroll_down", tooltip="Scroll down one line"),
+        HelpfulBinding("k, y", "scroll_up", tooltip="Scroll up one line"),
+        HelpfulBinding("f, space, z", "page_down", tooltip="Scroll down one page"),
+        HelpfulBinding("b, w", "page_up", tooltip="Scroll up one page"),
+        HelpfulBinding(
+            "shift+pageup, u", "scroll_half_page(-1)", tooltip="Scroll up half a page"
+        ),
+        HelpfulBinding(
+            "shift+pagedown, d",
+            "scroll_half_page(1)",
+            tooltip="Scroll down half a page",
+        ),
+    ]
+
+    def action_scroll_half_page(self, direction: Literal[-1, 1]) -> None:
+        """Scroll the view half a page in the given direction.
+
+        Args:
+            direction: The direction to scroll in.
+        """
+        self.scroll_relative(y=(self.size.height // 2) * direction)
+
+
+##############################################################################
 class Viewer(Vertical, can_focus=False):
     """The Markdown viewer widget."""
 
@@ -139,14 +174,6 @@ class Viewer(Vertical, can_focus=False):
 
     BINDINGS = [
         ("escape", "bounce_out"),
-        HelpfulBinding(
-            "shift+pageup", "scroll_half_page(-1)", tooltip="Scroll up half a page"
-        ),
-        HelpfulBinding(
-            "space, shift+pagedown",
-            "scroll_half_page(1)",
-            tooltip="Scroll down half a page",
-        ),
     ]
 
     location: var[HikeLocation | None] = var(None)
@@ -162,7 +189,7 @@ class Viewer(Vertical, can_focus=False):
         """Compose the content of the viewer."""
         yield ViewerTitle()
         yield Rule(line_style="heavy")
-        with VerticalScroll(id="document"):
+        with MarkdownScroll(id="document"):
             yield Markdown(
                 open_links=False,
                 parser_factory=lambda: MarkdownIt("gfm-like").use(
@@ -508,16 +535,6 @@ class Viewer(Vertical, can_focus=False):
             self.app.push_screen(
                 Editor(self.location), callback=lambda _: self.reload()
             )
-
-    def action_scroll_half_page(self, direction: Literal[-1, 1]) -> None:
-        """Scroll the Markdown half a page in the given direction.
-
-        Args:
-            direction: The direction to scroll in.
-        """
-        (view := self.get_child_by_type(VerticalScroll)).scroll_relative(
-            y=(view.size.height // 2) * direction
-        )
 
 
 ### viewer.py ends here


### PR DESCRIPTION
I'm not a vim user, never have been; I can quickly load, edit and save stuff with it in an emergency, but normally I'm an Emacs user like the gods intended. I use less fairly often but seldom live in it long enough to really have the muscle memory (if I need to really read something I'll load it in Emacs of course!).

So this is my attempt to make the document viewer widget itself a little more friendly to all.