### PR TITLE
Change the backup binding for jumping to the document

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 - Changed the alternative binding for jumping to the document to
   <kbd>ctrl</kbd>+<kbd>g</kbd> (<kbd>ctrl</kbd>+<kbd>r</kbd> was already
   used for reloading the document).
+  ([#68](https://github.com/davep/hike/pull/68))
 
 ## v0.8.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Hike ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Changed the alternative binding for jumping to the document to
+  <kbd>ctrl</kbd>+<kbd>g</kbd> (<kbd>ctrl</kbd>+<kbd>r</kbd> was already
+  used for reloading the document).
+
 ## v0.8.0
 
 **Released: 2025-03-31**

--- a/src/hike/commands/main.py
+++ b/src/hike/commands/main.py
@@ -32,7 +32,7 @@ class JumpToCommandLine(Command):
 class JumpToDocument(Command):
     """Jump to the markdown document"""
 
-    BINDING_KEY = "ctrl+slash, ctrl+r"
+    BINDING_KEY = "ctrl+slash, ctrl+g"
 
 
 ##############################################################################


### PR DESCRIPTION
The original choice of ctrl+r was already used for reloading the document; this is what you get for coding on a day off when you're full of cold and chilling after a weekend dash to the Netherlands and back.

Closes #67.