### PR TITLE
Provide a method of overriding the default application command keyboard bindings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@
   <kbd>ctrl</kbd>+<kbd>g</kbd> (<kbd>ctrl</kbd>+<kbd>r</kbd> was already
   used for reloading the document).
   ([#68](https://github.com/davep/hike/pull/68))
+- Added support for changing the keyboard bindings of the main application
+  commands. ([#69](https://github.com/davep/hike/pull/69))
+- Added `--bindings` as a command line switch; which lists all the commands
+  ([#69](https://github.com/davep/hike/pull/69))
 
 ## v0.8.0
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,7 +12,7 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.14
+aiohttp==3.11.15
     # via aiohttp-jinja2
     # via textual-dev
     # via textual-serve
@@ -69,7 +69,7 @@ mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.0
     # via textual-dev
-multidict==6.2.0
+multidict==6.3.0
     # via aiohttp
     # via yarl
 mypy==1.15.0
@@ -100,14 +100,14 @@ rich==14.0.0
     # via textual-serve
 sniffio==1.3.1
     # via anyio
-textual==3.0.0
+textual==3.0.1
     # via hike
     # via textual-dev
     # via textual-enhanced
     # via textual-fspicker
     # via textual-serve
 textual-dev==1.7.0
-textual-enhanced==0.9.0
+textual-enhanced==0.10.0
     # via hike
 textual-fspicker==0.4.1
     # via hike
@@ -120,7 +120,7 @@ typing-extensions==4.13.0
     # via textual-dev
 uc-micro-py==1.0.3
     # via linkify-it-py
-virtualenv==20.29.3
+virtualenv==20.30.0
     # via pre-commit
 xdg-base-dirs==6.0.2
     # via hike

--- a/requirements.lock
+++ b/requirements.lock
@@ -44,11 +44,11 @@ rich==14.0.0
     # via textual
 sniffio==1.3.1
     # via anyio
-textual==3.0.0
+textual==3.0.1
     # via hike
     # via textual-enhanced
     # via textual-fspicker
-textual-enhanced==0.9.0
+textual-enhanced==0.10.0
     # via hike
 textual-fspicker==0.4.1
     # via hike

--- a/src/hike/__main__.py
+++ b/src/hike/__main__.py
@@ -4,6 +4,7 @@
 # Python imports.
 from argparse import ArgumentParser, Namespace
 from inspect import cleandoc
+from operator import attrgetter
 
 ##############################################################################
 # Local imports.
@@ -43,6 +44,14 @@ def get_args() -> Namespace:
         action="store_true",
     )
 
+    # Add --bindings
+    parser.add_argument(
+        "-b",
+        "--bindings",
+        help="List commands that can have their bindings changed",
+        action="store_true",
+    )
+
     # The remainder is going to be the initial command.
     parser.add_argument(
         "command",
@@ -55,10 +64,32 @@ def get_args() -> Namespace:
 
 
 ##############################################################################
+def show_bindable_commands() -> None:
+    """Show the commands that can have bindings applied."""
+    from rich.console import Console
+    from rich.markup import escape
+
+    from .screens import Main
+
+    console = Console(highlight=False)
+    for command in sorted(Main.COMMAND_MESSAGES, key=attrgetter("__name__")):
+        if command().has_binding:
+            console.print(
+                f"[bold]{escape(command.__name__)}[/] [dim italic]- {escape(command.tooltip())}[/]"
+            )
+            console.print(
+                f"    [dim italic]Default: {escape(command.binding().key)}[/]"
+            )
+
+
+##############################################################################
 def main() -> None:
     """The main entry point."""
-    if (args := get_args()).license:
+    args = get_args()
+    if args.license:
         print(cleandoc(Hike.HELP_LICENSE))
+    elif args.bindings:
+        show_bindable_commands()
     else:
         Hike(args).run()
 

--- a/src/hike/data/config.py
+++ b/src/hike/data/config.py
@@ -48,6 +48,9 @@ class Configuration:
     local_start_location: str = "~"
     """The start location for the local file system browser."""
 
+    bindings: dict[str, str] = field(default_factory=dict)
+    """Command keyboard binding overrides."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/hike/hike.py
+++ b/src/hike/hike.py
@@ -67,6 +67,7 @@ class Hike(EnhancedApp[None]):
                 self.theme = configuration.theme
             except InvalidThemeError:
                 pass
+        self.update_keymap(configuration.bindings)
 
     def watch_theme(self) -> None:
         """Save the application's theme when it's changed."""


### PR DESCRIPTION
This PR adds a simple method of providing keyboard binding overrides for the main application commands. It also provides a new command line switch for Hike which will list all of the commands that can be overridden. For example:

![Screenshot 2025-04-01 at 16 55 37](https://github.com/user-attachments/assets/2415ff4d-8ef0-4c1d-92ac-fcc76711afcb)

Binding overrides as set via the configuration file; this is a dictionary in the file with the key being the name of the command and the value being the key or keys to bind, as a comma-separated list (note that due to [a bug in Textual](https://github.com/Textualize/textual/issues/5694) there must be no whitespace in the list). Key names are those that are defined by Textual.

Closes #56.
