### PR TITLE
Add `--navigation`/`--no-navigation` as command line options

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
   ([#74](https://github.com/davep/hike/pull/74))
 - Added `--navigation`/`--no-navigation` as command line switches; which
   lets the user control if he navigation panel is visible on startup.
+  ([#75](https://github.com/davep/hike/pull/75)).
 
 ## v0.9.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
 - Added `--theme` as a command line switch; which lets the user configure
   the theme via the command line.
   ([#74](https://github.com/davep/hike/pull/74))
+- Added `--navigation`/`--no-navigation` as command line switches; which
+  lets the user control if he navigation panel is visible on startup.
 
 ## v0.9.0
 

--- a/src/hike/__main__.py
+++ b/src/hike/__main__.py
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # Python imports.
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser, BooleanOptionalAction, Namespace
 from inspect import cleandoc
 from operator import attrgetter
 
@@ -50,6 +50,13 @@ def get_args() -> Namespace:
         "--bindings",
         help="List commands that can have their bindings changed",
         action="store_true",
+    )
+
+    # Add --navigation
+    parser.add_argument(
+        "--navigation",
+        help="Show or hide the navigation panel on startup",
+        action=BooleanOptionalAction,
     )
 
     # Add --theme

--- a/src/hike/screens/main.py
+++ b/src/hike/screens/main.py
@@ -187,7 +187,10 @@ class Main(EnhancedScreen[None]):
     def on_mount(self) -> None:
         """Configure the screen once the DOM is mounted."""
         config = load_configuration()
-        self.navigation_visible = config.navigation_visible
+        if self._arguments.navigation is None:
+            self.navigation_visible = config.navigation_visible
+        else:
+            self.navigation_visible = self._arguments.navigation
         self.query_one(Navigation).dock_right = config.navigation_on_right
         self.query_one(Navigation).bookmarks = (bookmarks := load_bookmarks())
         BookmarkCommands.bookmarks = bookmarks

--- a/src/hike/screens/main.py
+++ b/src/hike/screens/main.py
@@ -187,10 +187,11 @@ class Main(EnhancedScreen[None]):
     def on_mount(self) -> None:
         """Configure the screen once the DOM is mounted."""
         config = load_configuration()
-        if self._arguments.navigation is None:
-            self.navigation_visible = config.navigation_visible
-        else:
-            self.navigation_visible = self._arguments.navigation
+        self.navigation_visible = (
+            config.navigation_visible
+            if self._arguments.navigation is None
+            else self._arguments.navigation
+        )
         self.query_one(Navigation).dock_right = config.navigation_on_right
         self.query_one(Navigation).bookmarks = (bookmarks := load_bookmarks())
         BookmarkCommands.bookmarks = bookmarks


### PR DESCRIPTION
This lets the user specify if the navigation panel is visible on startup, from the command line.