### PR TITLE
Add more key aliases for scrolling the markdown document

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,9 @@
   Textual `OptionList`
   borkage](https://github.com/Textualize/textual/issues/5701).
   ([#77](https://github.com/davep/hike/issues/77))
+- Added some more movement key bindings (relating to going home and end) to
+  the markdown document that might be familiar to users of things like `vim`
+  and `less`.
 
 ## v0.9.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,7 @@
   ([#77](https://github.com/davep/hike/issues/77))
 - Added some more movement key bindings (relating to going home and end) to
   the markdown document that might be familiar to users of things like `vim`
-  and `less`.
+  and `less`. ([#82](https://github.com/davep/hike/pull/82))
 
 ## v0.9.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "textual>=2.1.1",
-    "textual-enhanced>=0.8.1",
+    "textual-enhanced>=0.11.0",
     "textual-fspicker>=0.4.1",
     "xdg-base-dirs>=6.0.2",
     "httpx>=0.28.1",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,7 +12,7 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.15
+aiohttp==3.11.16
     # via aiohttp-jinja2
     # via textual-dev
     # via textual-serve
@@ -69,7 +69,7 @@ mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.0
     # via textual-dev
-multidict==6.3.0
+multidict==6.2.0
     # via aiohttp
     # via yarl
 mypy==1.15.0
@@ -107,7 +107,7 @@ textual==3.0.1
     # via textual-fspicker
     # via textual-serve
 textual-dev==1.7.0
-textual-enhanced==0.10.0
+textual-enhanced==0.11.0
     # via hike
 textual-fspicker==0.4.1
     # via hike

--- a/requirements.lock
+++ b/requirements.lock
@@ -48,7 +48,7 @@ textual==3.0.1
     # via hike
     # via textual-enhanced
     # via textual-fspicker
-textual-enhanced==0.10.0
+textual-enhanced==0.11.0
     # via hike
 textual-fspicker==0.4.1
     # via hike


### PR DESCRIPTION
In this case vim/less-like keys for going home and end.

Closes #80.