### PR TITLE
Add the ability to search the history from the palette

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Hike ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Added an application command for searching history.
+  ([#90](https://github.com/davep/hike/pull/90))
+
 ## v0.10.0
 
 **Released: 2025-04-03**

--- a/src/hike/commands/__init__.py
+++ b/src/hike/commands/__init__.py
@@ -14,6 +14,7 @@ from .main import (
     Reload,
     SaveCopy,
     SearchBookmarks,
+    SearchHistory,
     ToggleNavigation,
 )
 from .navigation import (
@@ -45,6 +46,7 @@ __all__ = [
     "Reload",
     "SaveCopy",
     "SearchBookmarks",
+    "SearchHistory",
     "ToggleNavigation",
 ]
 

--- a/src/hike/commands/main.py
+++ b/src/hike/commands/main.py
@@ -67,7 +67,7 @@ class SearchBookmarks(Command):
 class SearchHistory(Command):
     """Search the history"""
 
-    BINDING_KEY = "ctrl+shift+y"
+    BINDING_KEY = "shift+f3"
 
 
 ##############################################################################

--- a/src/hike/commands/main.py
+++ b/src/hike/commands/main.py
@@ -64,6 +64,13 @@ class SearchBookmarks(Command):
 
 
 ##############################################################################
+class SearchHistory(Command):
+    """Search the history"""
+
+    BINDING_KEY = "ctrl+shift+y"
+
+
+##############################################################################
 class CopyLocationToClipboard(Command):
     """Copy the location to the clipboard"""
 

--- a/src/hike/providers/__init__.py
+++ b/src/hike/providers/__init__.py
@@ -3,12 +3,14 @@
 ##############################################################################
 # Local imports.
 from .bookmarks import BookmarkCommands
+from .history import HistoryCommands
 from .main import MainCommands
 
 ##############################################################################
 # Exports.
 __all__ = [
     "BookmarkCommands",
+    "HistoryCommands",
     "MainCommands",
 ]
 

--- a/src/hike/providers/history.py
+++ b/src/hike/providers/history.py
@@ -1,13 +1,71 @@
 """Bookmark search and visit commands for the command palette."""
 
 ##############################################################################
+# Python imports.
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import Final
+
+##############################################################################
+# httpx imports.
+from httpx import URL
+
+##############################################################################
+# Rich imports.
+from rich.emoji import Emoji
+
+##############################################################################
 # Textual enhanced imports.
 from textual_enhanced.commands import CommandHit, CommandHits, CommandsProvider
 
 ##############################################################################
 # Local imports.
 from ..messages import OpenLocation
-from ..types import HikeHistory
+from ..types import HikeHistory, HikeLocation
+
+##############################################################################
+# Icons.
+LOCAL_FILE: Final[str] = Emoji.replace(":page_facing_up:")
+"""Icon to use for a local file."""
+REMOTE_FILE: Final[str] = Emoji.replace(":globe_with_meridians:")
+"""icon to sue for a remote file."""
+
+
+##############################################################################
+@dataclass(frozen=True)
+@total_ordering
+class Historical:
+    """Holds a location from history."""
+
+    location: HikeLocation
+    """The location."""
+
+    @property
+    def name(self) -> str:
+        """A name for the location."""
+        if isinstance(self.location, URL):
+            return self.location.path
+        return str(self.location)
+
+    @property
+    def context(self) -> str:
+        """The context for the location."""
+        if isinstance(self.location, URL):
+            return f"{REMOTE_FILE} Remote on {self.location.host}"
+        return f"{LOCAL_FILE} Local file"
+
+    def __gt__(self, value: object, /) -> bool:
+        if isinstance(value, Historical):
+            return self.name.casefold() > value.name.casefold()
+        raise NotImplementedError
+
+    def __eq__(self, value: object, /) -> bool:
+        if isinstance(value, Historical):
+            return self.name == value.name
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return self.name
 
 
 ##############################################################################
@@ -28,13 +86,12 @@ class HistoryCommands(CommandsProvider):
         Yields:
             The commands for the command palette.
         """
-        # TODO: Unique and sort.
-        for location in self.history:
+        for location in sorted(set(Historical(location) for location in self.history)):
             # TODO: Improve what's shown in the palette.
             yield CommandHit(
-                f"{location}",
-                "",
-                OpenLocation(location),
+                location.name,
+                location.context,
+                OpenLocation(location.location),
             )
 
 

--- a/src/hike/providers/history.py
+++ b/src/hike/providers/history.py
@@ -1,0 +1,41 @@
+"""Bookmark search and visit commands for the command palette."""
+
+##############################################################################
+# Textual enhanced imports.
+from textual_enhanced.commands import CommandHit, CommandHits, CommandsProvider
+
+##############################################################################
+# Local imports.
+from ..messages import OpenLocation
+from ..types import HikeHistory
+
+
+##############################################################################
+class HistoryCommands(CommandsProvider):
+    """A command palette provider related to history."""
+
+    history: HikeHistory = HikeHistory()
+    """The history."""
+
+    @classmethod
+    def prompt(cls) -> str:
+        """The prompt for the command provider."""
+        return "Search history..."
+
+    def commands(self) -> CommandHits:
+        """Provide the history-based command data for the command palette.
+
+        Yields:
+            The commands for the command palette.
+        """
+        # TODO: Unique and sort.
+        for location in self.history:
+            # TODO: Improve what's shown in the palette.
+            yield CommandHit(
+                f"{location}",
+                "",
+                OpenLocation(location),
+            )
+
+
+### history.py ends here

--- a/src/hike/providers/main.py
+++ b/src/hike/providers/main.py
@@ -30,6 +30,7 @@ from ..commands import (
     Reload,
     SaveCopy,
     SearchBookmarks,
+    SearchHistory,
     ToggleNavigation,
 )
 
@@ -64,6 +65,7 @@ class MainCommands(CommandsProvider):
         yield from self.maybe(Reload)
         yield from self.maybe(SaveCopy)
         yield SearchBookmarks()
+        yield SearchHistory()
         yield ToggleNavigation()
 
 

--- a/src/hike/screens/main.py
+++ b/src/hike/screens/main.py
@@ -50,6 +50,7 @@ from ..commands import (
     Reload,
     SaveCopy,
     SearchBookmarks,
+    SearchHistory,
     ToggleNavigation,
 )
 from ..data import (
@@ -74,7 +75,7 @@ from ..messages import (
     RemoveHistoryEntry,
     SetLocalViewRoot,
 )
-from ..providers import BookmarkCommands, MainCommands
+from ..providers import BookmarkCommands, HistoryCommands, MainCommands
 from ..support import view_in_browser
 from ..widgets import CommandLine, Navigation, Viewer
 
@@ -154,6 +155,7 @@ class Main(EnhancedScreen[None]):
         Reload,
         SaveCopy,
         SearchBookmarks,
+        SearchHistory,
     )
 
     BINDINGS = Command.bindings(*COMMAND_MESSAGES)
@@ -390,6 +392,11 @@ class Main(EnhancedScreen[None]):
         """Search the bookmarks in the command palette."""
         self.show_palette(BookmarkCommands)
 
+    @on(SearchHistory)
+    def action_search_history_command(self) -> None:
+        """search the history in the command palette."""
+        self.show_palette(HistoryCommands)
+
     @on(ToggleNavigation)
     def action_toggle_navigation_command(self) -> None:
         """Toggle the display of the navigation panel."""
@@ -523,6 +530,7 @@ class Main(EnhancedScreen[None]):
         Args:
             message: The message to say that history changed.
         """
+        HistoryCommands.history = message.viewer.history
         self.query_one(Navigation).update_history(message.viewer.history)
         save_history(message.viewer.history)
 


### PR DESCRIPTION
Adds `SearchHistory` as an application command; using the Textual command palette to quickly search history. Bound to <kbd>shift</kbd>+<kbd>F3</kbd> by default.