### PR TITLE
Crop bookmarks and history the "improved" way

### DIFF
--- a/src/hike/widgets/navigation/bookmarks_view.py
+++ b/src/hike/widgets/navigation/bookmarks_view.py
@@ -10,10 +10,6 @@ from typing import cast
 from httpx import URL
 
 ##############################################################################
-# Rich imports.
-from rich.text import Text
-
-##############################################################################
 # Textual imports.
 from textual import on, work
 from textual.content import Content
@@ -46,23 +42,9 @@ class BookmarkView(Option):
         self.bookmark = bookmark
         """The bookmark."""
         super().__init__(
-            # From Textual 2.x onwards overflow="ellipsis" is broken in the
-            # "improved" OptionList.
-            #
-            # https://github.com/Textualize/textual/issues/5701
-            #
-            # The result is ugly as fuck, and as best as I can tell I can't
-            # achieve the originally-intended layout; at least it isn't as
-            # obvious and accessible as simply using a `Text` was. So for
-            # now I'm going to wrap this in Textual's new `Content` -- which
-            # seems to be Rich-like only worse -- and accept it looks as
-            # ugly as fuck but less ugly than without this workaround.
-            Content.from_rich_text(
-                Text.from_markup(
-                    f"{REMOTE_FILE_ICON if isinstance(bookmark.location, URL) else LOCAL_FILE_ICON} "
-                    f"[bold]{bookmark.title}[/]\n[dim]{bookmark.location}[/]",
-                    overflow="ellipsis",
-                )
+            Content.from_markup(
+                f"{REMOTE_FILE_ICON if isinstance(bookmark.location, URL) else LOCAL_FILE_ICON} "
+                f"[bold]{bookmark.title}[/]\n[dim]{bookmark.location}[/]",
             ),
             id=str(bookmark.location),
         )
@@ -76,6 +58,8 @@ class BookmarksView(EnhancedOptionList):
     BookmarksView {
         height: 1fr;
         border: none;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
         &:focus {
             border: none;
         }

--- a/src/hike/widgets/navigation/history_view.py
+++ b/src/hike/widgets/navigation/history_view.py
@@ -6,10 +6,6 @@ from pathlib import Path
 from typing import cast
 
 ##############################################################################
-# Rich imports.
-from rich.text import Text
-
-##############################################################################
 # Textual imports.
 from textual import on, work
 from textual.content import Content
@@ -42,25 +38,11 @@ class Location(Option):
         self.location_id = location_id
         """The ID of the location within the history."""
         super().__init__(
-            # From Textual 2.x onwards overflow="ellipsis" is broken in the
-            # "improved" OptionList.
-            #
-            # https://github.com/Textualize/textual/issues/5701
-            #
-            # The result is ugly as fuck, and as best as I can tell I can't
-            # achieve the originally-intended layout; at least it isn't as
-            # obvious and accessible as simply using a `Text` was. So for
-            # now I'm going to wrap this in Textual's new `Content` -- which
-            # seems to be Rich-like only worse -- and accept it looks as
-            # ugly as fuck but less ugly than without this workaround.
-            Content.from_rich_text(
-                Text.from_markup(
-                    f"{LOCAL_FILE_ICON} [bold]{location.name}[/]\n[dim]{location.parent}[/]"
-                    if isinstance(location, Path)
-                    else f"{REMOTE_FILE_ICON} [bold]{Path(location.path).name}[/]"
-                    f"\n[dim]{Path(location.path).parent}\n{location.host}[/]",
-                    overflow="ellipsis",
-                )
+            Content.from_markup(
+                f"{LOCAL_FILE_ICON} [bold]{location.name}[/]\n[dim]{location.parent}[/]"
+                if isinstance(location, Path)
+                else f"{REMOTE_FILE_ICON} [bold]{Path(location.path).name}[/]"
+                f"\n[dim]{Path(location.path).parent}\n{location.host}[/]"
             ),
             id=str(location_id),
         )
@@ -74,6 +56,8 @@ class HistoryView(EnhancedOptionList):
     HistoryView {
         height: 1fr;
         border: none;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
         &:focus {
             border: none;
         }


### PR DESCRIPTION
I have a suspicion that this isn't going to pan out in all situations, and I suspect that the deprecation of rich.text.Text in places like this might result in a degraded experience overall... but let's use it here anyway.