### PR TITLE
Reinstate some command line commands

### DIFF
--- a/src/hike/screens/main.py
+++ b/src/hike/screens/main.py
@@ -457,18 +457,22 @@ class Main(EnhancedScreen[None]):
         self.navigation_visible = True
         return self.query_one(Navigation)
 
+    @on(JumpToTableOfContents)
     def action_jump_to_table_of_contents_command(self) -> None:
         """Jump to the table of contents."""
         self._with_navigation_visible().jump_to_content()
 
+    @on(JumpToLocalBrowser)
     def action_jump_to_local_browser_command(self) -> None:
         """Jump to the local browser."""
         self._with_navigation_visible().jump_to_local()
 
+    @on(JumpToBookmarks)
     def action_jump_to_bookmarks_command(self) -> None:
         """Jump to the bookmarks."""
         self._with_navigation_visible().jump_to_bookmarks()
 
+    @on(JumpToHistory)
     def action_jump_to_history_command(self) -> None:
         """Jump to the history."""
         self._with_navigation_visible().jump_to_history()

--- a/src/hike/screens/main.py
+++ b/src/hike/screens/main.py
@@ -457,6 +457,11 @@ class Main(EnhancedScreen[None]):
         self.navigation_visible = True
         return self.query_one(Navigation)
 
+    @on(Quit)
+    def action_quit_command(self) -> None:
+        """Quit the application."""
+        self.app.exit()
+
     @on(JumpToTableOfContents)
     def action_jump_to_table_of_contents_command(self) -> None:
         """Jump to the table of contents."""

--- a/src/hike/widgets/command_line/general.py
+++ b/src/hike/widgets/command_line/general.py
@@ -46,7 +46,8 @@ class GeneralCommand(InputCommand):
             `True` if the command was handled; `False` if not.
         """
         if cls.is_command(text):
-            for_widget.post_message(cls.MESSAGE())
+            if (message := getattr(cls, "MESSAGE", None)) is not None:
+                for_widget.post_message(message())
             return True
         return False
 


### PR DESCRIPTION
I'd got a little carried away in #101. One of the benefits of the recent update to `textual-enhanced` is that there's no need to use `@on` to decorate command actions any more. Only... in Hike I also run various application commands from the command line by posting their message. In every other app I've built it's not an issue, but it is here.

This PR adds back some of the necessary handlers.