### PR TITLE
Pin Textual to <5.0.0 due to broken Markdown widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Hike ChangeLog
 
+## v1.1.1
+
+**Released: 2025-08-03**
+
+- Pinned Textual to <5.0.0 due to breaking and broken changes to the
+  `Markdown` widget.
+
 ## v1.1.0
 
 **Released: 2025-07-09**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "hike"
-version = "1.1.0"
+version = "1.1.1"
 description = "A Markdown browser for the terminal"
 authors = [
     { name = "Dave Pearson", email = "davep@davep.org" }
 ]
 dependencies = [
-    "textual>=2.1.1",
+    "textual<5.0.0",
     "textual-enhanced>=0.13.0",
     "textual-fspicker>=0.4.1",
     "xdg-base-dirs>=6.0.2",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,13 +12,13 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.18
+aiohttp==3.12.15
     # via aiohttp-jinja2
     # via textual-dev
     # via textual-serve
 aiohttp-jinja2==1.6
     # via textual-serve
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
 anyio==4.9.0
     # via httpx
@@ -26,38 +26,38 @@ attrs==25.3.0
     # via aiohttp
 babel==2.17.0
     # via mkdocs-material
-backrefs==5.8
+backrefs==5.9
     # via mkdocs-material
-certifi==2025.1.31
+certifi==2025.8.3
     # via httpcore
     # via httpx
     # via requests
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.1
     # via mkdocs
     # via textual-dev
 codespell==2.4.1
 colorama==0.4.6
     # via mkdocs-material
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 filelock==3.18.0
     # via virtualenv
-frozenlist==1.6.0
+frozenlist==1.7.0
     # via aiohttp
     # via aiosignal
 ghp-import==2.1.0
     # via mkdocs
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.8
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via hike
-identify==2.6.10
+identify==2.6.12
     # via pre-commit
 idna==3.10
     # via anyio
@@ -73,11 +73,11 @@ jinja2==3.1.6
     # via textual-serve
 linkify-it-py==2.0.3
     # via markdown-it-py
-markdown==3.8
+markdown==3.8.2
     # via mkdocs
     # via mkdocs-material
     # via pymdown-extensions
-markdown-exec==1.10.3
+markdown-exec==1.11.0
 markdown-it-py==3.0.0
     # via mdit-py-plugins
     # via rich
@@ -96,15 +96,15 @@ mkdocs==1.6.1
     # via mkdocs-material
 mkdocs-get-deps==0.2.0
     # via mkdocs
-mkdocs-material==9.6.12
+mkdocs-material==9.6.16
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-msgpack==1.1.0
+msgpack==1.1.1
     # via textual-dev
-multidict==6.4.3
+multidict==6.6.3
     # via aiohttp
     # via yarl
-mypy==1.15.0
+mypy==1.17.1
 mypy-extensions==1.1.0
     # via mypy
 nodeenv==1.9.1
@@ -116,25 +116,27 @@ paginate==0.5.7
     # via mkdocs-material
 pathspec==0.12.1
     # via mkdocs
-platformdirs==4.3.7
+    # via mypy
+platformdirs==4.3.8
     # via mkdocs-get-deps
     # via textual
     # via virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pre-commit==4.2.0
-propcache==0.3.1
+propcache==0.3.2
     # via aiohttp
     # via yarl
-pygments==2.19.1
+pygments==2.19.2
     # via mkdocs-material
+    # via pytest
     # via rich
-pymdown-extensions==10.14.3
+pymdown-extensions==10.16.1
     # via markdown-exec
     # via mkdocs-material
 pyperclip==1.9.0
     # via hike
-pytest==8.3.5
+pytest==8.4.1
 python-dateutil==2.9.0.post0
     # via ghp-import
 pyyaml==6.0.2
@@ -143,18 +145,18 @@ pyyaml==6.0.2
     # via pre-commit
     # via pymdown-extensions
     # via pyyaml-env-tag
-pyyaml-env-tag==0.1
+pyyaml-env-tag==1.1
     # via mkdocs
-requests==2.32.3
+requests==2.32.4
     # via mkdocs-material
-rich==14.0.0
+rich==14.1.0
     # via textual
     # via textual-serve
 six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
-textual==3.1.1
+textual==4.0.0
     # via hike
     # via textual-dev
     # via textual-enhanced
@@ -167,20 +169,20 @@ textual-fspicker==0.4.1
     # via hike
 textual-serve==1.1.2
     # via textual-dev
-typing-extensions==4.13.2
+typing-extensions==4.14.1
     # via hike
     # via mypy
     # via textual
     # via textual-dev
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
-virtualenv==20.30.0
+virtualenv==20.33.0
     # via pre-commit
 watchdog==6.0.0
     # via mkdocs
 xdg-base-dirs==6.0.2
     # via hike
-yarl==1.20.0
+yarl==1.20.1
     # via aiohttp

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,12 +12,12 @@
 -e file:.
 anyio==4.9.0
     # via httpx
-certifi==2025.1.31
+certifi==2025.8.3
     # via httpcore
     # via httpx
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.8
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via hike
@@ -34,17 +34,17 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via textual
-pygments==2.19.1
+pygments==2.19.2
     # via rich
 pyperclip==1.9.0
     # via hike
-rich==14.0.0
+rich==14.1.0
     # via textual
 sniffio==1.3.1
     # via anyio
-textual==3.1.1
+textual==4.0.0
     # via hike
     # via textual-enhanced
     # via textual-fspicker
@@ -52,7 +52,7 @@ textual-enhanced==0.13.0
     # via hike
 textual-fspicker==0.4.1
     # via hike
-typing-extensions==4.13.2
+typing-extensions==4.14.1
     # via hike
     # via textual
 uc-micro-py==1.0.3


### PR DESCRIPTION
Looks like Textual is back into another period of single-issue and single-app "improvements" that break things for no good reason. Let's be cautious until things settle down...