### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/style-lint-and-test.yaml
+++ b/.github/workflows/style-lint-and-test.yaml
@@ -13,8 +13,9 @@ jobs:
     name: Style, lint, test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
 
@@ -25,6 +26,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Documentation",
     "Topic :: Terminals",
     "Topic :: Text Processing :: Markup :: Markdown",


### PR DESCRIPTION
The reason for https://github.com/davep/hike/pull/123 is to be able to support Python 3.14.

Rye doesn't support 3.14 and won't either:

```console
$ echo 3.14 > .python-version
$ rye sync
error: Unable to determine target virtualenv Python version
```

So this PR requires #123 to be merged first, and then a merge or rebase from `main`.