### PR TITLE
WiP: Migrate from rye to uv (redux)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
-app    := hike
-src    := src/
-tests  := tests/
-docs   := docs/
-run    := uv run
-test   := uv run pytest
-python := $(run) python
-lint   := uv run ruff check --select I
-fmt    := uv run ruff format
-mypy   := $(run) mypy
-mkdocs := $(run) mkdocs
-spell  := $(run) codespell
+app     := hike
+src     := src/
+tests   := tests/
+docs    := docs/
+run     := uv run
+sync    := uv sync
+build   := uv build
+publish := uv publish --username=__token__ --keyring-provider=subprocess
+test    := $(run) pytest
+python  := $(run) python
+ruff    := $(run) ruff
+lint    := $(ruff) check --select I
+fmt     := $(ruff) format
+mypy    := $(run) mypy
+mkdocs  := $(run) mkdocs
+spell   := $(run) codespell
 
 ##############################################################################
 # Local "interactive testing" of the code.
@@ -33,12 +37,12 @@ console:			# Run the textual console
 # Setup/update packages the system requires.
 .PHONY: setup
 setup:				# Set up the repository for development
-	uv sync
+	$(sync)
 	$(run) pre-commit install
 
 .PHONY: update
 update:				# Update all dependencies
-	uv sync --update-all
+	$(sync) --update-all
 
 .PHONY: resetup
 resetup: realclean		# Recreate the virtual environment from scratch
@@ -91,19 +95,19 @@ publishdocs: clean-docs	# Set up the docs for publishing
 # Package/publish.
 .PHONY: package
 package:			# Package the library
-	uv build
+	$(build)
 
 .PHONY: spackage
 spackage:			# Create a source package for the library
-	uv build --sdist
+	$(build) --sdist
 
 .PHONY: testdist
 testdist: package			# Perform a test distribution
-	uv publish --yes --skip-existing --repository testpypi --repository-url https://test.pypi.org/legacy/
+	$(publish) --index testpypi
 
 .PHONY: dist
 dist: package			# Upload to pypi
-	uv publish --yes --skip-existing
+	echo $(publish)
 
 ##############################################################################
 # Utility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hike"
-version = "1.1.2"
+version = "1.1.2.4"
 description = "A Markdown browser for the terminal"
 authors = [
     { name = "Dave Pearson", email = "davep@davep.org" }
@@ -16,7 +16,7 @@ dependencies = [
 ]
 readme = "README.md"
 requires-python = ">= 3.10"
-license = { text = "GNU General Public License v3 or later (GPLv3+)" }
+license = "GPL-3.0-or-later"
 keywords = [
     "terminal",
     "tui",
@@ -34,7 +34,6 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Other Audience",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows :: Windows 10",
     "Operating System :: Microsoft :: Windows :: Windows 11",
@@ -63,12 +62,6 @@ Discussions = "https://github.com/davep/hike/discussions"
 [project.scripts]
 hike = "hike.__main__:main"
 
-[build-system]
-# https://github.com/astral-sh/rye/issues/1446
-requires = ["hatchling==1.26.3", "hatch-vcs"]
-# requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [tool.uv]
 managed = true
 dev-dependencies = [
@@ -92,3 +85,9 @@ packages = ["src/hike"]
 venvPath="."
 venv=".venv"
 exclude=[".venv"]
+
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true

--- a/uv.lock
+++ b/uv.lock
@@ -438,8 +438,8 @@ wheels = [
 
 [[package]]
 name = "hike"
-version = "1.1.2"
-source = { editable = "." }
+version = "1.1.2.4"
+source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
     { name = "pyperclip" },


### PR DESCRIPTION
NOTE: WIP PR; there's more to do but I'm trying to explore how to make best use of `uv` and to still be able to manage my package.

A second run at migrating from `ruff` to `uv` now that it seems that `rye` has been, in true Python package tooling fashion, abandoned. :-/

This is a re-working of the work put in by @hugovk while also wading through the various bits of documentation, issues, PRs and confused notes about how to handle publishing a package with `uv`.